### PR TITLE
disable BuildConfig generation

### DIFF
--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -26,6 +26,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    buildFeatures {
+        buildConfig = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This is a tiny build performance improvement.
`BuildConfig.java` isn't generated and packaged into the aar file so client apps don't have to strip it from the final apk again. 

Note, this is technically a breaking change as a public class is being removed. One that nobody should reference, but still.