### PR TITLE
fix: Set rootProject.name to Gradle approved characters

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 include ':connector'
-rootProject.name = "UnifiedPush Connector"
+rootProject.name = "android-connector"


### PR DESCRIPTION
Gradle wants the root project name to be from a small set of characters that, specifically, doesn't include " ".

This isn't a problem when this is a standalone project, but it is a problem if you try and include this code in another project as an "included build" -- for example, if you're developing changes to the library.

So rename to "android-connector" to match the module name.