### PR TITLE
 fix: Re-register if the active distributor was deleted 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }
 
 android {
@@ -39,10 +39,6 @@ android {
     }
 
     namespace "org.unifiedpush.android.connector"
-}
-
-dependencies {
-    api("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
 }
 
 // jitpack build

--- a/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
+++ b/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
@@ -72,7 +72,10 @@ object UnifiedPush {
         features: ArrayList<String> = DEFAULT_FEATURES,
         messageForDistributor: String = ""
     ) {
-        getAckDistributor(context)?.let {
+        val distributors = getDistributors(context, features)
+        val ackDistributor = getAckDistributor(context)
+
+        if (ackDistributor != null && distributors.contains(ackDistributor)) {
             registerApp(context, instance)
             return
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 27 08:55:12 CET 2023
+#Fri Aug 09 16:31:50 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The user might register with a distributor, and then delete the
distributor app.

If that happens the user is not prompted if there are no distributors,
and re-registration does not happen.

Fix this by checking the ack'ed distributor is still in the list of
installed distributors.