### PR TITLE
 fix: Update "No distributor found" dialog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }
 
 android {
@@ -39,10 +39,6 @@ android {
     }
 
     namespace "org.unifiedpush.android.connector"
-}
-
-dependencies {
-    api("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
 }
 
 // jitpack build

--- a/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
+++ b/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
@@ -72,7 +72,10 @@ object UnifiedPush {
         features: ArrayList<String> = DEFAULT_FEATURES,
         messageForDistributor: String = ""
     ) {
-        getAckDistributor(context)?.let {
+        val distributors = getDistributors(context, features)
+        val ackDistributor = getAckDistributor(context)
+
+        if (ackDistributor != null && distributors.contains(ackDistributor)) {
             registerApp(context, instance)
             return
         }

--- a/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
+++ b/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
@@ -85,23 +85,24 @@ object UnifiedPush {
         when (distributors.size) {
             0 -> {
                 if (!Store(context).getNoDistributorAck()) {
-                    val message = TextView(context)
-                    val builder = AlertDialog.Builder(context)
-                    val s = SpannableString(registrationDialogContent.noDistributorDialog.message)
-                    Linkify.addLinks(s, Linkify.WEB_URLS)
-                    message.text = s
-                    message.movementMethod = LinkMovementMethod.getInstance()
-                    message.setPadding(32, 32, 32, 32)
-                    builder.setTitle(registrationDialogContent.noDistributorDialog.title)
-                    builder.setView(message)
-                    builder.setPositiveButton(registrationDialogContent.noDistributorDialog.okButton) {
-                            _, _ ->
+                    val builder = AlertDialog.Builder(context).apply {
+                        setTitle(registrationDialogContent.noDistributorDialog.title)
+                        val msg =
+                            SpannableString(registrationDialogContent.noDistributorDialog.message)
+                        Linkify.addLinks(msg, Linkify.WEB_URLS)
+                        setMessage(msg)
+                        setPositiveButton(registrationDialogContent.noDistributorDialog.okButton) { _, _ -> }
+                        setNegativeButton(registrationDialogContent.noDistributorDialog.ignoreButton) { _, _ ->
+                            Store(context).saveNoDistributorAck()
+                        }
                     }
-                    builder.setNegativeButton(registrationDialogContent.noDistributorDialog.ignoreButton) {
-                            _, _ ->
-                        Store(context).saveNoDistributorAck()
+                    val dialog = builder.create()
+                    dialog.setOnShowListener {
+                        dialog.findViewById<TextView>(android.R.id.message)?.let {
+                            it.movementMethod = LinkMovementMethod.getInstance()
+                        }
                     }
-                    builder.show()
+                    dialog.show()
                 } else {
                     Log.d(LOG_TAG, "User already know there isn't any distributor")
                 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 27 08:55:12 CET 2023
+#Fri Aug 09 16:31:50 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Previous code ignored the dialog's default layout and set its own
textview. I think this was so a LinkMovementMethod could be set on the
message.

This meant the view didn't follow normal Android dialog dimensions
(e.g., padding, margins, text layout), and looked out of place.

Fix this. Use the normal AlertDialog message. Set an onShowListener
that sets the LinkMovementMethod when the dialog is shown.