### PR TITLE
 fix(l10n): Use resource strings for default dialog string resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/connector/build.gradle
+++ b/connector/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }
 
 android {
@@ -39,10 +39,6 @@ android {
     }
 
     namespace "org.unifiedpush.android.connector"
-}
-
-dependencies {
-    api("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
 }
 
 // jitpack build

--- a/connector/src/main/java/org/unifiedpush/android/connector/RegistrationDialogContent.kt
+++ b/connector/src/main/java/org/unifiedpush/android/connector/RegistrationDialogContent.kt
@@ -1,20 +1,65 @@
 package org.unifiedpush.android.connector
 
-data class RegistrationDialogContent(
-    val noDistributorDialog: NoDistributorDialog = NoDistributorDialog(),
-    val chooseDialog: ChooseDialog = ChooseDialog()
-)
+import android.content.Context
 
-data class NoDistributorDialog(
-    var title: String = "No distributor found",
-    var message: String = "You need to install a distributor " +
-        "for push notifications to work.\n" +
-        "For more information, visit\n" +
-        "https://unifiedpush.org/",
-    var okButton: String = "OK",
-    var ignoreButton: String = "Ignore"
-)
+/** Defines content that can be shown during [UnifiedPush.registerAppWithDialog]. */
+interface RegistrationDialogContent {
+    /** Content if no distributor is installed. */
+    val noDistributorDialog: NoDistributorDialog
 
-data class ChooseDialog(
-    var title: String = "Choose a distributor"
-)
+    /** Content if multiple distributors are installed. */
+    val chooseDialog: ChooseDialog
+}
+
+/**
+ * Default [RegistrationDialogContent]
+ *
+ * @param context Context for fetching resources.
+ */
+data class DefaultRegistrationDialogContent(val context: Context) : RegistrationDialogContent {
+    override val noDistributorDialog = DefaultNoDistributorDialog(context)
+    override val chooseDialog = DefaultChooseDialog(context)
+}
+
+/** Defines content for the dialog if no distributors are installed. */
+interface NoDistributorDialog {
+    /** Dialog title. */
+    val title: String
+
+    /** Dialog message. */
+    var message: String
+
+    /** Text on positive button */
+    val okButton: String
+
+    /** Text on negative button. */
+    val ignoreButton: String
+}
+
+/**
+ * Default [NoDistributorDialog].
+ *
+ * @param context Context for fetching resources.
+ */
+data class DefaultNoDistributorDialog(val context: Context) : NoDistributorDialog {
+    override val title = context.getString(R.string.unified_push_dialog_no_distributor_title)
+    override var message = context.getString(R.string.unified_push_dialog_no_distributor_message)
+    override val okButton = context.getString(android.R.string.ok)
+    override val ignoreButton =
+        context.getString(R.string.unified_push_dialog_no_distributor_negative)
+}
+
+/** Defines content for the dialog if multiple distributors are installed. */
+interface ChooseDialog {
+    /** Dialog title. */
+    val title: String
+}
+
+/**
+ * Default [ChooseDialog].
+ *
+ * @param context Context for fetching resources.
+ */
+data class DefaultChooseDialog(val context: Context) : ChooseDialog {
+    override val title = context.getString(R.string.unified_push_dialog_choose_title)
+}

--- a/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
+++ b/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
@@ -57,7 +57,9 @@ object UnifiedPush {
         registerAppWithDialog(
             context,
             instance,
-            RegistrationDialogContent().apply { noDistributorDialog.message = dialogMessage },
+            DefaultRegistrationDialogContent(context).apply {
+                noDistributorDialog.message = dialogMessage
+            },
             features,
             messageForDistributor
         )
@@ -68,7 +70,7 @@ object UnifiedPush {
         context: Context,
         instance: String = INSTANCE_DEFAULT,
         registrationDialogContent: RegistrationDialogContent =
-            RegistrationDialogContent(),
+            DefaultRegistrationDialogContent(context),
         features: ArrayList<String> = DEFAULT_FEATURES,
         messageForDistributor: String = ""
     ) {

--- a/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
+++ b/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
@@ -72,7 +72,10 @@ object UnifiedPush {
         features: ArrayList<String> = DEFAULT_FEATURES,
         messageForDistributor: String = ""
     ) {
-        getAckDistributor(context)?.let {
+        val distributors = getDistributors(context, features)
+        val ackDistributor = getAckDistributor(context)
+
+        if (ackDistributor != null && distributors.contains(ackDistributor)) {
             registerApp(context, instance)
             return
         }

--- a/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
+++ b/connector/src/main/java/org/unifiedpush/android/connector/UnifiedPush.kt
@@ -85,23 +85,24 @@ object UnifiedPush {
         when (distributors.size) {
             0 -> {
                 if (!Store(context).getNoDistributorAck()) {
-                    val message = TextView(context)
-                    val builder = AlertDialog.Builder(context)
-                    val s = SpannableString(registrationDialogContent.noDistributorDialog.message)
-                    Linkify.addLinks(s, Linkify.WEB_URLS)
-                    message.text = s
-                    message.movementMethod = LinkMovementMethod.getInstance()
-                    message.setPadding(32, 32, 32, 32)
-                    builder.setTitle(registrationDialogContent.noDistributorDialog.title)
-                    builder.setView(message)
-                    builder.setPositiveButton(registrationDialogContent.noDistributorDialog.okButton) {
-                            _, _ ->
+                    val builder = AlertDialog.Builder(context).apply {
+                        setTitle(registrationDialogContent.noDistributorDialog.title)
+                        val msg =
+                            SpannableString(registrationDialogContent.noDistributorDialog.message)
+                        Linkify.addLinks(msg, Linkify.WEB_URLS)
+                        setMessage(msg)
+                        setPositiveButton(registrationDialogContent.noDistributorDialog.okButton) { _, _ -> }
+                        setNegativeButton(registrationDialogContent.noDistributorDialog.ignoreButton) { _, _ ->
+                            Store(context).saveNoDistributorAck()
+                        }
                     }
-                    builder.setNegativeButton(registrationDialogContent.noDistributorDialog.ignoreButton) {
-                            _, _ ->
-                        Store(context).saveNoDistributorAck()
+                    val dialog = builder.create()
+                    dialog.setOnShowListener {
+                        dialog.findViewById<TextView>(android.R.id.message)?.let {
+                            it.movementMethod = LinkMovementMethod.getInstance()
+                        }
                     }
-                    builder.show()
+                    dialog.show()
                 } else {
                     Log.d(LOG_TAG, "User already know there isn't any distributor")
                 }

--- a/connector/src/main/res/values/strings.xml
+++ b/connector/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <string name="unified_push_dialog_no_distributor_title">No distributor found</string>
+    <string name="unified_push_dialog_no_distributor_message">You need to install a distributor for push notifications to work\n\nFor more information visit https://unifiedpush.org.</string>
+    <string name="unified_push_dialog_no_distributor_negative">Don\'t tell me again</string>
+
+    <string name="unified_push_dialog_choose_title">Choose a distributor</string>
+</resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 27 08:55:12 CET 2023
+#Fri Aug 09 16:31:50 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 include ':connector'
-rootProject.name = "UnifiedPush Connector"
+rootProject.name = "android-connector"


### PR DESCRIPTION
The strings used in default dialogs were hardcoded. This meant they
couldn't be translated, or use the default platform strings (e.g.,
android.R.string.ok).

Fix that. Convert `RegistrationDialogContent`, `NoDistributorDialog`,
and `ChooseDialog` to interfaces, and provide implementations of those
interfaces that use the default strings.